### PR TITLE
Use correct calculation for fixed yields

### DIFF
--- a/src/efi-ui/pools/hooks/usePrincipalTokenYield.ts
+++ b/src/efi-ui/pools/hooks/usePrincipalTokenYield.ts
@@ -42,7 +42,8 @@ export function usePrincipalTokenYield(
     // fixed apy = fixed interest * one_year / term_length
     if (timeLeftInSeconds > 0) {
       fixedAPR =
-        ((1 - principalPrice) * ONE_YEAR_IN_SECONDS) / timeLeftInSeconds;
+        (((1 - principalPrice) / principalPrice) * ONE_YEAR_IN_SECONDS) /
+        timeLeftInSeconds;
     } else {
       fixedAPR = 0;
     }

--- a/src/efi-ui/pools/hooks/useTokenYield.tsx
+++ b/src/efi-ui/pools/hooks/useTokenYield.tsx
@@ -42,7 +42,8 @@ export function useTokenYield(
     // fixed apy = fixed interest * one_year / term_length
     if (timeLeftInSeconds > 0) {
       fixedAPY =
-        ((1 - principalPrice) * ONE_YEAR_IN_SECONDS) / timeLeftInSeconds;
+        (((1 - principalPrice) / principalPrice) * ONE_YEAR_IN_SECONDS) /
+        timeLeftInSeconds;
     } else {
       fixedAPY = 0;
     }


### PR DESCRIPTION
We should be using the following formula:

fixed apy = (interest gained)/(principal) * 365 / (term length). previously we were assuming a principal amount of 1, where it should be principal token price (relative to base asset) instead.