### PR TITLE
Add script to prevent unwanted vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,8 @@
     "test:coverage": "npm run test -- --coverage --watchAll=false",
     "update-elf-contracts-typechain": "npm install git+https://github.com/element-fi/elf-contracts-typechain.git",
     "update-elf-tokenlist": "npm install git+https://github.com/element-fi/elf-tokenlist.git",
-    "update:language": "bash ./scripts/update-language.sh"
+    "update:language": "bash ./scripts/update-language.sh",
+    "vercel-build-check": "bash ./scripts/vercel-build-check.sh"
   },
   "version": "0.1.0"
 }

--- a/scripts/vercel-build-check.sh
+++ b/scripts/vercel-build-check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "VERCEL_ENV: $VERCEL_ENV"
+
+if [[ "$VERCEL_ENV" == "production" ]] ; then
+  # Proceed with the build
+  echo ":white_check_mark: - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo ":octagonal_sign: - Build cancelled"
+  exit 0;
+fi


### PR DESCRIPTION
### Description

This adds a script that will be run in Vercel to determine if a new build is required and prevents unwanted builds (such as changes meant for staging) from being deployed on preview URLs on the mainnet and testnet projects.

This script is run from the Vercel project's git settings under "Ignored Build Step".
