### PR TITLE
Ryan readme update

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   test-coverage:
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ First install the dependencies. Open the directory in your terminal and run:
 npm ci
 ```
 
-  > **note:** Running `npm ci` instead of just `npm i` or `npm install` will ensure that the package-lock.json isn'tmodified if you're using a different version of npm. See the [npm-ci docs](https://docs.npmjs.com/cli/v8/commands/npm-ci) for more info.
+  > **note:** Running `npm ci` instead of just `npm i` or `npm install` will ensure that the package-lock.json isn't modified if you're using a different version of npm. See the [npm-ci docs](https://docs.npmjs.com/cli/v8/commands/npm-ci) for more info.
 
 To start the app in development mode:
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 ## Building for production
 
-### `npm run build:new <addresses-json-id>`
-
-Example:
-
-Create a prod build against the element Goerli contracts
-```
-npm run build:new goerli
-```
+| Network          | Command                     |
+|------------------|-----------------------------|
+| Hardhat          | `npm run build`             |
+| Goerli           | `npm run build:goerli-app`  |
+| Ethereum Mainnet | `npm run build:mainnet-app` |
 
 ## Developer setup
 
@@ -17,7 +14,7 @@ First install the dependencies. Open the directory in your terminal and run:
 npm ci
 ```
 
-  > **note:** Running `npm ci` instead of just `npm i` or `npm install` will ensure that the package-lock.json isn't modified if you're using a different version of npm. See the [npm-ci docs](https://docs.npmjs.com/cli/v8/commands/npm-ci) for more info.
+  > **note:** Running `npm ci` instead of just `npm i` or `npm install` will ensure that the package-lock.json isn'tmodified if you're using a different version of npm. See the [npm-ci docs](https://docs.npmjs.com/cli/v8/commands/npm-ci) for more info.
 
 To start the app in development mode:
 
@@ -38,3 +35,29 @@ npm start
 1. Run `npm run update-elf-tokenlist`.
 1. Add a logo svg to `src/efi-static-assets/svg/` directory.
 1. Update `src/addresses/AddressesJsonFile.d.ts`
+
+## Deployment
+
+This app is deployed to 3 different projects in [Vercel](https://vercel.com/element-finance).
+
+### 1. [elf-frontend-staging](https://vercel.com/element-finance/elf-frontend-staging)
+
+This is a password protected app accessible at [staging.element.fi][staging-app-url]. It uses `main` as it's production branch and will create a new [preview deployment](https://vercel.com/docs/concepts/deployments/environments#preview) each time there's a push to *any* branch or a deployment is made using the [`vercel` command](https://vercel.com/docs/concepts/deployments/overview#vercel-cli).
+
+Once a branch has been merged into `main`, it will be deployed to [staging.element.fi][staging-app-url].
+
+### 2. [elf-frontend-testnet](https://vercel.com/element-finance/elf-frontend-testnet)
+
+This is the Goerli app accessible at [testnet.element.fi][testnet-app-url] and uses `testnet` as it's production branch.
+
+After merging a branch into `main`, merge `main` into `testnet` to deploy to [testnet.element.fi][testnet-app-url].
+
+### 3. [elf-frontend](https://vercel.com/element-finance/elf-frontend)
+
+This is the main app accessible at [app.element.fi][mainnet-app-url] and uses `mainnet` as it's production branch.
+
+After merging a branch into `main`, merge `main` into `mainnet` to deploy to [app.element.fi][mainnet-app-url].
+
+[staging-app-url]: https://staging.element.fi
+[testnet-app-url]: https://testnet.element.fi
+[mainnet-app-url]: https://app.element.fi

--- a/README.md
+++ b/README.md
@@ -42,19 +42,19 @@ This app is deployed to 3 different projects in [Vercel](https://vercel.com/elem
 
 ### 1. [elf-frontend-staging](https://vercel.com/element-finance/elf-frontend-staging)
 
-This is a password protected app accessible at [staging.element.fi][staging-app-url]. It uses `main` as it's production branch and will create a new [preview deployment](https://vercel.com/docs/concepts/deployments/environments#preview) each time there's a push to *any* branch or a deployment is made using the [`vercel` command](https://vercel.com/docs/concepts/deployments/overview#vercel-cli).
+This is a password protected app accessible at [staging.element.fi][staging-app-url]. It uses `main` as its production branch and will create a new [preview deployment](https://vercel.com/docs/concepts/deployments/environments#preview) each time there's a push to *any* branch or a deployment is made using the [`vercel` command](https://vercel.com/docs/concepts/deployments/overview#vercel-cli).
 
 Once a branch has been merged into `main`, it will be deployed to [staging.element.fi][staging-app-url].
 
 ### 2. [elf-frontend-testnet](https://vercel.com/element-finance/elf-frontend-testnet)
 
-This is the Goerli app accessible at [testnet.element.fi][testnet-app-url] and uses `testnet` as it's production branch.
+This is the Goerli app accessible at [testnet.element.fi][testnet-app-url] and uses `testnet` as its production branch.
 
 After merging a branch into `main`, merge `main` into `testnet` to deploy to [testnet.element.fi][testnet-app-url].
 
 ### 3. [elf-frontend](https://vercel.com/element-finance/elf-frontend)
 
-This is the main app accessible at [app.element.fi][mainnet-app-url] and uses `mainnet` as it's production branch.
+This is the main app accessible at [app.element.fi][mainnet-app-url] and uses `mainnet` as its production branch.
 
 After merging a branch into `main`, merge `main` into `mainnet` to deploy to [app.element.fi][mainnet-app-url].
 


### PR DESCRIPTION
### Description

- Updated build details in README. The `build:new <addresses-json-id>` script was removed in the Next.js migration to make build options discoverable and prevent accidentally passing an ID that didn't exist.
- Added deployment details for Vercel. The element.fi domains haven't been updated yet, but it's been requested from Jonny.
- Added a check in the Test Coverage workflow to skip it on PRs from dependabot.
