### PR TITLE
Simplify extracting the vault apy from yearn

### DIFF
--- a/src/efi-yearn/fetchYearnVaults.ts
+++ b/src/efi-yearn/fetchYearnVaults.ts
@@ -10,10 +10,7 @@ export async function fetchYearnVaults(): Promise<YearnVaultResult[]> {
 export function getYearnVaultAPY(
   apyFromYearn: YearnVaultResult["apy"]
 ): number {
-  const { points, net_apy } = apyFromYearn;
-  if (points) {
-    return points.week_ago;
-  }
+  const { net_apy } = apyFromYearn;
   return net_apy;
 }
 


### PR DESCRIPTION
### Description

Always use `net_apy`.

![image](https://user-images.githubusercontent.com/4524175/145637650-b671cf88-ea6e-49c9-a4e6-35fbf2120079.png)


### Screenshots

|Mobile Portrait|Mobile Landscape|Desktop|
|---|---|---|
| mobile_portrait_img | mobile_landscape_img | desktop_img | 
