### PR TITLE
Mainnet-fork compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Building for production
 
 | Network          | Command                     |
-|------------------|-----------------------------|
+| ---------------- | --------------------------- |
 | Hardhat          | `npm run build`             |
 | Goerli           | `npm run build:goerli-app`  |
 | Ethereum Mainnet | `npm run build:mainnet-app` |
@@ -14,7 +14,7 @@ First install the dependencies. Open the directory in your terminal and run:
 npm ci
 ```
 
-  > **note:** Running `npm ci` instead of just `npm i` or `npm install` will ensure that the package-lock.json isn't modified if you're using a different version of npm. See the [npm-ci docs](https://docs.npmjs.com/cli/v8/commands/npm-ci) for more info.
+> **note:** Running `npm ci` instead of just `npm i` or `npm install` will ensure that the package-lock.json isn't modified if you're using a different version of npm. See the [npm-ci docs](https://docs.npmjs.com/cli/v8/commands/npm-ci) for more info.
 
 To start the app in development mode:
 
@@ -32,9 +32,48 @@ npm start
 ```
 
 ### Adding a new base asset
+
 1. Run `npm run update-elf-tokenlist`.
 1. Add a logo svg to `src/efi-static-assets/svg/` directory.
 1. Update `src/addresses/AddressesJsonFile.d.ts`
+
+### Running against a mainnet fork environment
+
+It may be useful for some to develop against a mainnet fork environment and we can use [elf-frontend-testnet](https://github.com/element-fi/elf-frontend-testnet) to do so. In a separate directory, clone the elf-frontend-testnet repository and install the dependencies as outlined.
+
+##### Importing the developer address
+
+The next step is to import the target testnet developer address into your Metamask wallet.
+
+```bash
+Address       0x70997970c51812dc3a010c7d01b50e0d17dc79c8
+Private Key:  0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d # <- Import this
+```
+
+The purpose of doing this is so we can finance a wallet with a basket of ERC20 tokens required to interact with the system. **IMPORTANT**, this address is a default hardhat address and as such should never be sent real mainnet funds as they will be stolen.
+
+##### Running the mainnet fork node
+
+In the elf-frontend-testnet directory, run:
+
+```bash
+npm run start-mainnet:dev
+```
+
+##### Running the frontend against the mainnet fork node
+
+In a separate terminal, `cd` into the this frontend's directory and run:
+
+```bash
+npm run start:dev-mainnet-fork-app
+```
+
+This will spin up the frontend as normal. It will be noticeably slower in initial instances as hardhat will have to first retrieve real state but will be cached in future instances. This will repeat itself when the target blocknumber is changed.
+
+##### Metamask related issues
+
+1. Sometimes metamask can be out of sync and will attempt to cache on the basis of blocknumber last seen. This is known as ["tagging"](https://ethereum.stackexchange.com/questions/109625/received-invalid-block-tag-87-latest-block-number-is-0) and will most likely occur when the node is restarted, resetting the blocknumber. This can be circumvented as instructed from the link and so it is advised to set your network to some other and back again to localhost
+2. When submitting transactions, there may be a nonce issue which is also due to metamask caching. This can be annoying but can be manually edited with the correct one. Usually if a transaction is attempted there should be an error log in the console which should mention the correct one.
 
 ## Deployment
 
@@ -42,7 +81,7 @@ This app is deployed to 3 different projects in [Vercel](https://vercel.com/elem
 
 ### 1. [elf-frontend-staging](https://vercel.com/element-finance/elf-frontend-staging)
 
-This is a password protected app accessible at [staging.element.fi][staging-app-url]. It uses `main` as its production branch and will create a new [preview deployment](https://vercel.com/docs/concepts/deployments/environments#preview) each time there's a push to *any* branch or a deployment is made using the [`vercel` command](https://vercel.com/docs/concepts/deployments/overview#vercel-cli).
+This is a password protected app accessible at [staging.element.fi][staging-app-url]. It uses `main` as its production branch and will create a new [preview deployment](https://vercel.com/docs/concepts/deployments/environments#preview) each time there's a push to _any_ branch or a deployment is made using the [`vercel` command](https://vercel.com/docs/concepts/deployments/overview#vercel-cli).
 
 Once a branch has been merged into `main`, it will be deployed to [staging.element.fi][staging-app-url].
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In the elf-frontend-testnet directory, run:
 npm run start-mainnet:dev
 ```
 
-##### Running the frontend against the mainnet fork node
+##### Developing against the Mainnet fork environment
 
 In a separate terminal, `cd` into the this frontend's directory and run:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Address       0x70997970c51812dc3a010c7d01b50e0d17dc79c8
 Private Key:  0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d # <- Import this
 ```
 
-The purpose of doing this is so we can finance a wallet with a basket of ERC20 tokens required to interact with the system. **IMPORTANT**, this address is a default hardhat address and as such should never be sent real mainnet funds as they will be stolen.
+The purpose of doing this is so we can finance a wallet with a basket of ERC20 tokens required to interact with the system. **IMPORTANT! This address is a default hardhat address and as such should never be sent real mainnet funds as they will be stolen**.
 
 ##### Running the mainnet fork node
 
@@ -62,7 +62,7 @@ npm run start-mainnet:dev
 
 ##### Developing against the Mainnet fork environment
 
-In a separate terminal, `cd` into the this frontend's directory and run:
+In a separate terminal, `cd` into this repo's directory and run:
 
 ```bash
 npm run start:dev-mainnet-fork-app

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "start:dev-goerli-app": "npm run start:dev goerli",
     "start:dev-mainnet-app": "npm run start:dev mainnet",
     "start:dev-testnet-app": "npm run start:dev testnet",
+    "start:dev-mainnet-fork-app": "npm run start:dev mainnet_fork",
     "test": "jest",
     "test:coverage": "npm run test -- --coverage --watchAll=false",
     "update-elf-contracts-typechain": "npm install git+https://github.com/element-fi/elf-contracts-typechain.git",

--- a/src/efi/addresses/addresses.ts
+++ b/src/efi/addresses/addresses.ts
@@ -12,12 +12,19 @@ function getAddressesJsonId() {
     return "mock";
   }
 
+  if (process.env.NEXT_PUBLIC_CHAIN_NAME === "mainnet_fork") {
+    return "mainnet";
+  }
+
   return process.env.NEXT_PUBLIC_CHAIN_NAME || "testnet";
 }
 
 function getAddressesJson(): AddressesJsonFile {
   if (addressesJsonId === "testnet") {
-    return AddressesJsonFileTestnet;
+    return {
+      ...AddressesJsonFileMainnet,
+      chainId: AddressesJsonFileTestnet.chainId,
+    }; //AddressesJsonFileTestnet;
   }
 
   if (addressesJsonId === "mock") {
@@ -25,7 +32,13 @@ function getAddressesJson(): AddressesJsonFile {
   }
 
   if (addressesJsonId === "mainnet") {
-    return AddressesJsonFileMainnet;
+    return {
+      ...AddressesJsonFileMainnet,
+      chainId:
+        process.env.NEXT_PUBLIC_CHAIN_NAME === "mainnet_fork"
+          ? AddressesJsonFileTestnet.chainId
+          : AddressesJsonFileMainnet.chainId,
+    };
   }
 
   if (addressesJsonId === "goerli") {

--- a/src/efi/canperform/canperform.ts
+++ b/src/efi/canperform/canperform.ts
@@ -8,6 +8,10 @@ function getCanPerformJsonId() {
     return "mock";
   }
 
+  if (process.env.NEXT_PUBLIC_CHAIN_NAME === "mainnet_fork") {
+    return "mainnet";
+  }
+
   return process.env.NEXT_PUBLIC_CHAIN_NAME || "testnet";
 }
 

--- a/src/efi/ethereum/ethereum.ts
+++ b/src/efi/ethereum/ethereum.ts
@@ -28,9 +28,12 @@ export function isGoerli(chainId: number): boolean {
   return chainId === ChainId.GOERLI;
 }
 export function isMainnet(chainId: number): boolean {
-  return chainId === ChainId.MAINNET;
+  return (
+    chainId === ChainId.MAINNET ||
+    (chainId === ChainId.LOCAL &&
+      process.env.NEXT_PUBLIC_CHAIN_NAME === "mainnet_fork")
+  );
 }
-
 export const NUM_ETH_DECIMALS = 18;
 export const ONE_ETHER = parseUnits("1", NUM_ETH_DECIMALS);
 

--- a/src/efi/tokenlists/tokenlists.ts
+++ b/src/efi/tokenlists/tokenlists.ts
@@ -52,5 +52,9 @@ function getTokenListJsonId() {
     return "mock";
   }
 
+  if (process.env.NEXT_PUBLIC_CHAIN_NAME === "mainnet_fork") {
+    return "mainnet";
+  }
+
   return process.env.NEXT_PUBLIC_CHAIN_NAME || "testnet";
 }


### PR DESCRIPTION
Related to https://github.com/element-fi/elf-frontend-testnet/pull/1

The gist of this is to utilise the mainnet addresses and tokenlist whilst targeting a localhost environment. I've added instructions in the readme which should explain what is necessary to set it all up