### PR TITLE
Add new DAI term

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2105,9 +2105,9 @@
       }
     },
     "@elementfi/tokenlist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@elementfi/tokenlist/-/tokenlist-1.0.1.tgz",
-      "integrity": "sha512-TR0agYmIeh4uMTC44l2X6Ga4L+9nd1UCevFizfUtTf78DB7No7Ew+OY+pw+oE1N1IcTrZcRipPN+qXj6u5EjYA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@elementfi/tokenlist/-/tokenlist-1.1.0.tgz",
+      "integrity": "sha512-/BGAZiChTAPRNgrsG52OmYSd8oknj7YLNCk3bW4UZPSBylJRIwE1582m0NdvTz5thRKZv7raiHOeyjDADQzBpg==",
       "requires": {
         "@uniswap/token-lists": "^1.0.0-beta.25",
         "tsc": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@blueprintjs/icons": "^3.31.0",
     "@blueprintjs/popover2": "^0.12.8",
     "@blueprintjs/select": "^3.18.11",
-    "@elementfi/tokenlist": "^1.0.1",
+    "@elementfi/tokenlist": "^1.1.0",
     "@ethersproject/abi": "^5.5.0",
     "@ethersproject/abstract-signer": "^5.4.1",
     "@ethersproject/bytes": "^5.4.0",


### PR DESCRIPTION
### Description

The latest dai term was deployed here: https://github.com/element-fi/elf-deploy/pull/101

The tokenlist was updated to v1.1.0 to reflect this: https://github.com/element-fi/elf-tokenlist/releases/tag/v1.1.0

This PR updates the tokenlist dependency so that the UI will display the new term, see screenshot below.

### Screenshots

![image](https://user-images.githubusercontent.com/4524175/148164989-b08bb6b6-fe0a-4d94-9b62-427b4fc07c54.png)

### New Term Checklist
- [x] Check that the Vault APY matches what is reported for the vault on yearn.finance
- [x] Check that the UI fixed rate APY matches the Initial APR we agreed to initialize to.
- [x] Check term date is correct number of months or days and ends on a Friday.
