### PR TITLE
fix rounding error for mint UI

### DIFF
--- a/src/ui/mint/hooks/useMintPreview.ts
+++ b/src/ui/mint/hooks/useMintPreview.ts
@@ -66,10 +66,13 @@ export function useMintPreview(
   const vaultTotalAssets = +formatUnits(vaultTotalAssetsBN, vaultDecimals);
   const vaultTotalSupply = +formatUnits(vaultTotalSupplyBN, vaultDecimals);
 
-  const interestPerUnderlying =
+  // avoid rounding errors for UI, don't let interest be negative
+  const interestPerUnderlying = Math.max(
     ((balanceBefore * vaultTotalAssets) / vaultTotalSupply -
       trancheValueSupplied) /
-    trancheInterestSupply;
+      trancheInterestSupply,
+    0
+  );
 
   const adjustedAmount = +amountIn - +amountIn * interestPerUnderlying;
   return adjustedAmount;


### PR DESCRIPTION
there is a slight rounding error that is possible that can cause interestPerUnderlying to be slightly negative.  prevent that so the UI doesn't show minting more principal tokens than amount of base asset put in.