### PR TITLE
Remove websocket provider in favor of http, due to alchemy infrastructure change

### DIFF
--- a/src/elf/providers/providers.ts
+++ b/src/elf/providers/providers.ts
@@ -6,10 +6,12 @@ import { AddressesJson } from "addresses/addresses";
 import { ChainId } from "base/ethereum/ethereum";
 
 const LOCAL_RPC_HOST = "http://127.0.0.1:8545";
+
 const ALCHEMY_GOERLI_KEY = process.env.NEXT_PUBLIC_GOERLI_ALCHEMY_KEY as string;
+export const ALCHEMY_GOERLI_HTTP_URL = `https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_GOERLI_KEY}`;
+
 const ALCHEMY_MAINNET_KEY = process.env
   .NEXT_PUBLIC_MAINNET_ALCHEMY_KEY as string;
-export const ALCHEMY_GOERLI_HTTP_URL = `https://eth-goerli.alchemyapi.io/v2/${ALCHEMY_GOERLI_KEY}`;
 export const ALCHEMY_MAINNET_HTTP_URL = `https://eth-mainnet.alchemyapi.io/v2/${ALCHEMY_MAINNET_KEY}`;
 
 // eslint-disable-next-line no-var
@@ -27,9 +29,7 @@ function getProvider() {
   // otherwise, if a chain id is provided, we'll use the corresponding alchemy provider.  right now
   // this is only goerli.
   if (AddressesJson.chainId === ChainId.GOERLI) {
-    const web3Goerli = createAlchemyWeb3(
-      `wss://eth-goerli.ws.alchemyapi.io/v2/${ALCHEMY_GOERLI_KEY}`,
-    );
+    const web3Goerli = createAlchemyWeb3(ALCHEMY_GOERLI_HTTP_URL);
     const alchemyWeb3GoerliWebSocketProvider = new providers.Web3Provider(
       web3Goerli.currentProvider as ExternalProvider,
       ChainId.GOERLI,
@@ -38,9 +38,7 @@ function getProvider() {
   }
 
   if (AddressesJson.chainId === ChainId.MAINNET) {
-    const web3Mainnet = createAlchemyWeb3(
-      `wss://eth-mainnet.ws.alchemyapi.io/v2/${ALCHEMY_MAINNET_KEY}`,
-    );
+    const web3Mainnet = createAlchemyWeb3(ALCHEMY_MAINNET_HTTP_URL);
 
     const alchemyWeb3MainnetWebSocketProvider = new providers.Web3Provider(
       web3Mainnet.currentProvider as ExternalProvider,


### PR DESCRIPTION
Switching back to http for alchemy connections based on a heads up from Alchemy:

> Our engineering team is rolling out a few changes to harden our websocket infrastructure. As a result, there will be a cap of 10 concurrent requests per websocket connection. We highly recommend requests be sent over HTTP, even if websocket connections are used for subscriptions.
>
> We plan to make this change asap this week, so please let me know when you get a chance to make this fix! And let me know if you have any further questions!

We initially switched from http providers to websockets in order to improve response times for `decimals()`, `symbol()` calls, etc.. however we adopted tokenlist shortly after the switch, which reduced our our request load significantly. Keeping websockets around didn't hurt, but we also don't need to continue using it, especially with these new changes from Alchemy.

TL;DR: This should be a mostly undetectable change to our app's network performance.